### PR TITLE
Add mine item category and crystal currency

### DIFF
--- a/src/main/java/com/maks/ingredientpouchplugin/ItemManager.java
+++ b/src/main/java/com/maks/ingredientpouchplugin/ItemManager.java
@@ -105,6 +105,77 @@ public class ItemManager {
         addItem("leaf_II", Material.KELP, "&5[ II ] Leaf", "KOPALNIA", "&7&oBasic crafting material");
         addItem("leaf_III", Material.KELP, "&6[ III ] Leaf", "KOPALNIA", "&7&oBasic crafting material");
 
+        // Items from category MINE
+        addItem("hematite", Material.COAL_ORE, "&8Hematite", "MINE",
+                "&7A common black ore with metallic luster and reddish streaks.",
+                "&eCoal-based mineral");
+        addItem("black_spinel", Material.COAL_ORE, "&8Black Spinel", "MINE",
+                "&7An uncommon black crystal with exceptional hardness and luster.",
+                "&eCoal-based gemstone");
+        addItem("black_diamond", Material.COAL_ORE, "&8&lBlack Diamond", "MINE",
+                "&7A rare and precious black diamond formed under extreme pressure.",
+                "&eHighest quality coal gem");
+
+        addItem("magnetite", Material.IRON_ORE, "&7Magnetite", "MINE",
+                "&7A common metallic ore with magnetic properties.",
+                "&eIron-based mineral");
+        addItem("silver", Material.IRON_ORE, "&f&lSilver", "MINE",
+                "&7An uncommon precious metal with lustrous white appearance.",
+                "&eIron-based metal");
+        addItem("osmium", Material.IRON_ORE, "&7&lOsmium", "MINE",
+                "&7A rare and dense bluish-white metal, one of the heaviest natural elements.",
+                "&ePremium iron metal");
+
+        addItem("azurite", Material.LAPIS_ORE, "&9Azurite", "MINE",
+                "&7A common deep blue mineral with intense azure color.",
+                "&eLapis-based mineral");
+        addItem("tanzanite", Material.LAPIS_ORE, "&9&lTanzanite", "MINE",
+                "&7An uncommon blue-purple gemstone known for its trichroic properties.",
+                "&eLapis-based gem");
+        addItem("blue_sapphire", Material.LAPIS_ORE, "&1&lBlue Sapphire", "MINE",
+                "&7A rare and precious blue gemstone, second only to diamond in hardness.",
+                "&ePremium lapis gem");
+
+        addItem("carnelian", Material.REDSTONE_ORE, "&cCarnelian", "MINE",
+                "&7A common reddish-orange mineral with translucent properties.",
+                "&eRedstone-based mineral");
+        addItem("red_spinel", Material.REDSTONE_ORE, "&c&lRed Spinel", "MINE",
+                "&7An uncommon vibrant red gemstone often mistaken for ruby.",
+                "&eRedstone-based gem");
+        addItem("pigeon_blood_ruby", Material.REDSTONE_ORE, "&4&lPigeon Blood Ruby", "MINE",
+                "&7A rare and precious deep red gemstone with the coveted \"pigeon blood\" color.",
+                "&ePremium redstone gem");
+
+        addItem("pyrite", Material.GOLD_ORE, "&ePyrite", "MINE",
+                "&7A common brassy-yellow mineral often called \"Fool`s Gold\".",
+                "&eGold-based mineral");
+        addItem("yellow_topaz", Material.GOLD_ORE, "&e&lYellow Topaz", "MINE",
+                "&7An uncommon golden-yellow gemstone with excellent clarity.",
+                "&eGold-based gem");
+        addItem("yellow_sapphire", Material.GOLD_ORE, "&6&lYellow Sapphire", "MINE",
+                "&7A rare and precious golden gemstone, prized for its brilliance and hardness.",
+                "&ePremium gold gem");
+
+        addItem("malachite", Material.EMERALD_ORE, "&aMalachite", "MINE",
+                "&7A common green mineral with distinctive banded patterns.",
+                "&eEmerald-based mineral");
+        addItem("peridot", Material.EMERALD_ORE, "&a&lPeridot", "MINE",
+                "&7An uncommon olive-green gemstone formed in volcanic environments.",
+                "&eEmerald-based gem");
+        addItem("tropiche_emerald", Material.EMERALD_ORE, "&2&lTropiche Emerald", "MINE",
+                "&7A rare and precious deep green gemstone with exceptional clarity and color.",
+                "&ePremium emerald");
+
+        addItem("danburite", Material.DIAMOND_ORE, "&fDanburite", "MINE",
+                "&7A common colorless crystal with diamond-like brilliance.",
+                "&eDiamond-based mineral");
+        addItem("goshenite", Material.DIAMOND_ORE, "&f&lGoshenite", "MINE",
+                "&7An uncommon colorless beryl with exceptional clarity.",
+                "&eDiamond-based gemstone");
+        addItem("cerussite", Material.DIAMOND_ORE, "&f&l&nCerussite", "MINE",
+                "&7A rare and precious crystal with the highest refractive index.",
+                "&eSupreme diamond gemstone");
+
         // Przedmioty z kategorii LOWISKO (Łowisko)
         addItem("alga_I", Material.HORN_CORAL, "&9[ I ] Algal", "LOWISKO", "&7&oBasic crafting material");
         addItem("alga_II", Material.HORN_CORAL, "&5[ II ] Algal", "LOWISKO", "&7&oBasic crafting material");
@@ -126,22 +197,24 @@ public class ItemManager {
         addItem("jewel_dust", Material.INK_SAC, "§9Jewel Dust", "CURRENCY", "&7&oUsed to upgrade jewels");
         addItem("shiny_dust", Material.GLOW_INK_SAC, "§5Shiny Dust", "CURRENCY", "&7&oUsed to upgrade gems");
         addItem("rune_dust", Material.CLAY_BALL, "§cRune Dust", "CURRENCY", "&7&oUsed to upgrade runes");
+        addItem("crystal", Material.BRICK, "&d&lCrystal", "CURRENCY", "&7&oMine currency");
 
         plugin.getLogger().info("Loaded " + items.size() + " items.");
     }
 
 
-    private void addItem(String itemId, Material material, String displayName, @NotNull String category, String loreText) {
+    private void addItem(String itemId, Material material, String displayName, @NotNull String category, String... loreText) {
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
 
         // Translate color codes in the display name
         meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', displayName));
 
-        // Apply loreText directly, translating color codes
+        // Apply lore, translating color codes for each line
         List<String> lore = new ArrayList<>();
-        String formattedLore = ChatColor.translateAlternateColorCodes('&', loreText);
-        lore.add(formattedLore);
+        for (String line : loreText) {
+            lore.add(ChatColor.translateAlternateColorCodes('&', line));
+        }
         meta.setLore(lore);
 
         // Set any additional item meta properties here

--- a/src/main/java/com/maks/ingredientpouchplugin/PouchGUI.java
+++ b/src/main/java/com/maks/ingredientpouchplugin/PouchGUI.java
@@ -49,7 +49,7 @@ public class PouchGUI {
 
         // Define specific category order: 1-CURRENCY, 2-EXPO, 3-MONSTER_FRAGMENTS, 4-Q, 5-KOPALNIA, 6-LOWISKO
         List<String> orderedCategories = new ArrayList<>();
-        String[] categoryOrder = {"CURRENCY", "EXPO", "MONSTER_FRAGMENTS", "Q", "KOPALNIA", "LOWISKO"};
+        String[] categoryOrder = {"CURRENCY", "EXPO", "MONSTER_FRAGMENTS", "Q", "KOPALNIA", "MINE", "LOWISKO"};
 
         // Add categories in specified order
         for (String category : categoryOrder) {

--- a/src/main/resources/item_list.yml
+++ b/src/main/resources/item_list.yml
@@ -836,6 +836,301 @@ leaf_III:
     HideFlags: true
     Unbreakable: true
 
+# Przedmioty z kategorii MINE
+hematite:
+  Id: coal_ore
+  Display: '&8Hematite'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A common black ore with metallic luster and reddish streaks.'
+    - '&eCoal-based mineral'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+black_spinel:
+  Id: coal_ore
+  Display: '&8Black Spinel'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7An uncommon black crystal with exceptional hardness and luster.'
+    - '&eCoal-based gemstone'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+black_diamond:
+  Id: coal_ore
+  Display: '&8&lBlack Diamond'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A rare and precious black diamond formed under extreme pressure.'
+    - '&eHighest quality coal gem'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+magnetite:
+  Id: iron_ore
+  Display: '&7Magnetite'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A common metallic ore with magnetic properties.'
+    - '&eIron-based mineral'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+silver:
+  Id: iron_ore
+  Display: '&f&lSilver'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7An uncommon precious metal with lustrous white appearance.'
+    - '&eIron-based metal'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+osmium:
+  Id: iron_ore
+  Display: '&7&lOsmium'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A rare and dense bluish-white metal, one of the heaviest natural elements.'
+    - '&ePremium iron metal'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+azurite:
+  Id: lapis_ore
+  Display: '&9Azurite'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A common deep blue mineral with intense azure color.'
+    - '&eLapis-based mineral'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+tanzanite:
+  Id: lapis_ore
+  Display: '&9&lTanzanite'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7An uncommon blue-purple gemstone known for its trichroic properties.'
+    - '&eLapis-based gem'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+blue_sapphire:
+  Id: lapis_ore
+  Display: '&1&lBlue Sapphire'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A rare and precious blue gemstone, second only to diamond in hardness.'
+    - '&ePremium lapis gem'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+carnelian:
+  Id: redstone_ore
+  Display: '&cCarnelian'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A common reddish-orange mineral with translucent properties.'
+    - '&eRedstone-based mineral'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+red_spinel:
+  Id: redstone_ore
+  Display: '&c&lRed Spinel'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7An uncommon vibrant red gemstone often mistaken for ruby.'
+    - '&eRedstone-based gem'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+pigeon_blood_ruby:
+  Id: redstone_ore
+  Display: '&4&lPigeon Blood Ruby'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A rare and precious deep red gemstone with the coveted "pigeon blood" color.'
+    - '&ePremium redstone gem'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+pyrite:
+  Id: gold_ore
+  Display: '&ePyrite'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A common brassy-yellow mineral often called "Fool`s Gold".'
+    - '&eGold-based mineral'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+yellow_topaz:
+  Id: gold_ore
+  Display: '&e&lYellow Topaz'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7An uncommon golden-yellow gemstone with excellent clarity.'
+    - '&eGold-based gem'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+yellow_sapphire:
+  Id: gold_ore
+  Display: '&6&lYellow Sapphire'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A rare and precious golden gemstone, prized for its brilliance and hardness.'
+    - '&ePremium gold gem'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+malachite:
+  Id: emerald_ore
+  Display: '&aMalachite'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A common green mineral with distinctive banded patterns.'
+    - '&eEmerald-based mineral'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+peridot:
+  Id: emerald_ore
+  Display: '&a&lPeridot'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7An uncommon olive-green gemstone formed in volcanic environments.'
+    - '&eEmerald-based gem'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+tropiche_emerald:
+  Id: emerald_ore
+  Display: '&2&lTropiche Emerald'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A rare and precious deep green gemstone with exceptional clarity and color.'
+    - '&ePremium emerald'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+danburite:
+  Id: diamond_ore
+  Display: '&fDanburite'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A common colorless crystal with diamond-like brilliance.'
+    - '&eDiamond-based mineral'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+goshenite:
+  Id: diamond_ore
+  Display: '&f&lGoshenite'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7An uncommon colorless beryl with exceptional clarity.'
+    - '&eDiamond-based gemstone'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+cerussite:
+  Id: diamond_ore
+  Display: '&f&l&nCerussite'
+  Group: mine
+  Category: MINE
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '&7A rare and precious crystal with the highest refractive index.'
+    - '&eSupreme diamond gemstone'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
 # Przedmioty z kategorii LOWISKO (Łowisko)
 alga_I:
   Id: horn_coral
@@ -990,6 +1285,19 @@ andermant:
     DURABILITY: 10
   Lore:
     - '§o&7Premium currency'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+crystal:
+  Id: brick
+  Display: '&d&lCrystal'
+  Group: Currency
+  Category: CURRENCY
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&7Mine currency'
   Options:
     HideFlags: true
     Unbreakable: true


### PR DESCRIPTION
## Summary
- add extensive "MINE" item category with numerous ore and gem entries
- support multi-line lore definitions and add new `Crystal` currency item
- include "MINE" in pouch category ordering

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899bb545d8c832a84e26dd09637565d