### PR TITLE
Match MINE items by name only for pouch integration

### DIFF
--- a/src/main/java/com/maks/mycraftingplugin2/integration/PouchIntegrationHelper.java
+++ b/src/main/java/com/maks/mycraftingplugin2/integration/PouchIntegrationHelper.java
@@ -349,11 +349,17 @@ public class PouchIntegrationHelper {
      */
     private static boolean isMatchingItem(ItemStack item1, ItemStack item2, String baseItemName) {
         if (item1 == null || item2 == null) return false;
-        if (item1.getType() != item2.getType()) return false;
-        
+
         String name1 = getBaseItemName(item1);
         String name2 = baseItemName != null ? baseItemName : getBaseItemName(item2);
-        
+
+        // For items in the MINE category, match solely by display name
+        if (PouchItemMappings.isMineCategoryItem(name1) || PouchItemMappings.isMineCategoryItem(name2)) {
+            return name1.equals(name2);
+        }
+
+        if (item1.getType() != item2.getType()) return false;
+
         return name1.equals(name2);
     }
     

--- a/src/main/java/com/maks/mycraftingplugin2/integration/PouchItemMappings.java
+++ b/src/main/java/com/maks/mycraftingplugin2/integration/PouchItemMappings.java
@@ -2,6 +2,9 @@ package com.maks.mycraftingplugin2.integration;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.HashSet;
+import java.util.Arrays;
+import java.util.Set;
 
 /**
  * Complete mappings between display names and pouch item IDs
@@ -10,6 +13,29 @@ import java.util.Map;
 public class PouchItemMappings {
     
     private static final Map<String, String> itemMappings = new HashMap<>();
+    private static final Set<String> mineItems = new HashSet<>(Arrays.asList(
+        "Hematite",
+        "Black Spinel",
+        "Black Diamond",
+        "Magnetite",
+        "Silver",
+        "Osmium",
+        "Azurite",
+        "Tanzanite",
+        "Blue Sapphire",
+        "Carnelian",
+        "Red Spinel",
+        "Pigeon Blood Ruby",
+        "Pyrite",
+        "Yellow Topaz",
+        "Yellow Sapphire",
+        "Malachite",
+        "Peridot",
+        "Tropiche Emerald",
+        "Danburite",
+        "Goshenite",
+        "Cerussite"
+    ));
     
     static {
         initializeMappings();
@@ -87,7 +113,30 @@ public class PouchItemMappings {
         itemMappings.put("[ I ] Leaf", "leaf_I");
         itemMappings.put("[ II ] Leaf", "leaf_II");
         itemMappings.put("[ III ] Leaf", "leaf_III");
-        
+
+        // MINE category items
+        itemMappings.put("Hematite", "hematite");
+        itemMappings.put("Black Spinel", "black_spinel");
+        itemMappings.put("Black Diamond", "black_diamond");
+        itemMappings.put("Magnetite", "magnetite");
+        itemMappings.put("Silver", "silver");
+        itemMappings.put("Osmium", "osmium");
+        itemMappings.put("Azurite", "azurite");
+        itemMappings.put("Tanzanite", "tanzanite");
+        itemMappings.put("Blue Sapphire", "blue_sapphire");
+        itemMappings.put("Carnelian", "carnelian");
+        itemMappings.put("Red Spinel", "red_spinel");
+        itemMappings.put("Pigeon Blood Ruby", "pigeon_blood_ruby");
+        itemMappings.put("Pyrite", "pyrite");
+        itemMappings.put("Yellow Topaz", "yellow_topaz");
+        itemMappings.put("Yellow Sapphire", "yellow_sapphire");
+        itemMappings.put("Malachite", "malachite");
+        itemMappings.put("Peridot", "peridot");
+        itemMappings.put("Tropiche Emerald", "tropiche_emerald");
+        itemMappings.put("Danburite", "danburite");
+        itemMappings.put("Goshenite", "goshenite");
+        itemMappings.put("Cerussite", "cerussite");
+
         // LOWISKO (fishing) category items
         itemMappings.put("[ I ] Algal", "alga_I");
         itemMappings.put("[ II ] Algal", "alga_II");
@@ -133,7 +182,11 @@ public class PouchItemMappings {
         
         return null;
     }
-    
+
+    public static boolean isMineCategoryItem(String displayName) {
+        return mineItems.contains(displayName);
+    }
+
     /**
      * Add custom mapping
      */


### PR DESCRIPTION
## Summary
- track MythicMobs MINE ore display names in a dedicated set
- check only display name for MINE items when comparing inventory entries

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b3615a8d0832a884d6c59af817bdd