### PR TITLE
Add farming item category

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Minecraft plugin that adds a virtual pouch system for storing crafting ingredi
 ## Features
 
 - **Virtual Storage System**: Store items without taking up physical inventory space
-- **Category Organization**: Items automatically sorted by categories (EXPO, Q, KOPALNIA, LOWISKO, CURRENCY)
+- **Category Organization**: Items automatically sorted by categories (EXPO, MONSTER_FRAGMENTS, Q, KOPALNIA, MINE, FARMING, LOWISKO, CURRENCY)
 - **Paginated GUI**: Easy-to-navigate interface with previous/next page buttons
 - **Database Integration**: Secure MySQL storage with HikariCP connection pooling
 - **Item Management**: Support for custom items with special properties

--- a/src/main/java/com/maks/ingredientpouchplugin/ItemManager.java
+++ b/src/main/java/com/maks/ingredientpouchplugin/ItemManager.java
@@ -176,6 +176,43 @@ public class ItemManager {
                 "&7A rare and precious crystal with the highest refractive index.",
                 "&eSupreme diamond gemstone");
 
+        // Items from category FARMING
+        addItem("farmer_plant_fiber_I", Material.STRING, "&9[ I ] Plant Fiber", "FARMING", "&7&oBasic crafting material");
+        addItem("farmer_plant_fiber_II", Material.STRING, "&5[ II ] Plant Fiber", "FARMING", "&7&oBasic crafting material");
+        addItem("farmer_plant_fiber_III", Material.STRING, "&6[ III ] Plant Fiber", "FARMING", "&7&oBasic crafting material");
+
+        addItem("farmer_seed_pouch_I", Material.WHEAT_SEEDS, "&9[ I ] Seed Pouch", "FARMING", "&7&oBasic crafting material");
+        addItem("farmer_seed_pouch_II", Material.WHEAT_SEEDS, "&5[ II ] Seed Pouch", "FARMING", "&7&oBasic crafting material");
+        addItem("farmer_seed_pouch_III", Material.WHEAT_SEEDS, "&6[ III ] Seed Pouch", "FARMING", "&7&oBasic crafting material");
+
+        addItem("farmer_compost_dust_I", Material.BONE_MEAL, "&9[ I ] Compost Dust", "FARMING", "&7&oBasic crafting material");
+        addItem("farmer_compost_dust_II", Material.BONE_MEAL, "&5[ II ] Compost Dust", "FARMING", "&7&oBasic crafting material");
+        addItem("farmer_compost_dust_III", Material.BONE_MEAL, "&6[ III ] Compost Dust", "FARMING", "&7&oBasic crafting material");
+
+        addItem("farmer_herb_extract_I", Material.SPIDER_EYE, "&9[ I ] Herbal Extract", "FARMING", "&a&oRare crafting material");
+        addItem("farmer_herb_extract_II", Material.SPIDER_EYE, "&5[ II ] Herbal Extract", "FARMING", "&a&oRare crafting material");
+        addItem("farmer_herb_extract_III", Material.SPIDER_EYE, "&6[ III ] Herbal Extract", "FARMING", "&a&oRare crafting material");
+
+        addItem("farmer_mushroom_spores_I", Material.BROWN_MUSHROOM, "&9[ I ] Mushroom Spores", "FARMING", "&a&oRare crafting material");
+        addItem("farmer_mushroom_spores_II", Material.BROWN_MUSHROOM, "&5[ II ] Mushroom Spores", "FARMING", "&a&oRare crafting material");
+        addItem("farmer_mushroom_spores_III", Material.BROWN_MUSHROOM, "&6[ III ] Mushroom Spores", "FARMING", "&a&oRare crafting material");
+
+        addItem("farmer_beeswax_chunk_I", Material.BOOK, "&9[ I ] Beeswax Chunk", "FARMING", "&a&oRare crafting material");
+        addItem("farmer_beeswax_chunk_II", Material.BOOK, "&5[ II ] Beeswax Chunk", "FARMING", "&a&oRare crafting material");
+        addItem("farmer_beeswax_chunk_III", Material.BOOK, "&6[ III ] Beeswax Chunk", "FARMING", "&a&oRare crafting material");
+
+        addItem("farmer_druidic_essence_I", Material.GLOW_INK_SAC, "&9[ I ] Druidic Essence", "FARMING", "&c&oLegendary crafting material");
+        addItem("farmer_druidic_essence_II", Material.GLOW_INK_SAC, "&5[ II ] Druidic Essence", "FARMING", "&c&oLegendary crafting material");
+        addItem("farmer_druidic_essence_III", Material.GLOW_INK_SAC, "&6[ III ] Druidic Essence", "FARMING", "&c&oLegendary crafting material");
+
+        addItem("farmer_golden_truffle_I", Material.GOLDEN_CARROT, "&9[ I ] Golden Truffle", "FARMING", "&c&oLegendary crafting material");
+        addItem("farmer_golden_truffle_II", Material.GOLDEN_CARROT, "&5[ II ] Golden Truffle", "FARMING", "&c&oLegendary crafting material");
+        addItem("farmer_golden_truffle_III", Material.GOLDEN_CARROT, "&6[ III ] Golden Truffle", "FARMING", "&c&oLegendary crafting material");
+
+        addItem("farmer_ancient_grain_I", Material.HAY_BLOCK, "&9[ I ] Ancient Grain Sheaf", "FARMING", "&c&oLegendary crafting material");
+        addItem("farmer_ancient_grain_II", Material.HAY_BLOCK, "&5[ II ] Ancient Grain Sheaf", "FARMING", "&c&oLegendary crafting material");
+        addItem("farmer_ancient_grain_III", Material.HAY_BLOCK, "&6[ III ] Ancient Grain Sheaf", "FARMING", "&c&oLegendary crafting material");
+
         // Przedmioty z kategorii LOWISKO (Łowisko)
         addItem("alga_I", Material.HORN_CORAL, "&9[ I ] Algal", "LOWISKO", "&7&oBasic crafting material");
         addItem("alga_II", Material.HORN_CORAL, "&5[ II ] Algal", "LOWISKO", "&7&oBasic crafting material");

--- a/src/main/java/com/maks/ingredientpouchplugin/PouchGUI.java
+++ b/src/main/java/com/maks/ingredientpouchplugin/PouchGUI.java
@@ -47,9 +47,9 @@ public class PouchGUI {
 
         int pageIndex = 1;
 
-        // Define specific category order: 1-CURRENCY, 2-EXPO, 3-MONSTER_FRAGMENTS, 4-Q, 5-KOPALNIA, 6-LOWISKO
+        // Define specific category order: 1-CURRENCY, 2-EXPO, 3-MONSTER_FRAGMENTS, 4-Q, 5-KOPALNIA, 6-MINE, 7-FARMING, 8-LOWISKO
         List<String> orderedCategories = new ArrayList<>();
-        String[] categoryOrder = {"CURRENCY", "EXPO", "MONSTER_FRAGMENTS", "Q", "KOPALNIA", "MINE", "LOWISKO"};
+        String[] categoryOrder = {"CURRENCY", "EXPO", "MONSTER_FRAGMENTS", "Q", "KOPALNIA", "MINE", "FARMING", "LOWISKO"};
 
         // Add categories in specified order
         for (String category : categoryOrder) {

--- a/src/main/java/com/maks/mycraftingplugin2/integration/PouchItemMappings.java
+++ b/src/main/java/com/maks/mycraftingplugin2/integration/PouchItemMappings.java
@@ -137,6 +137,35 @@ public class PouchItemMappings {
         itemMappings.put("Goshenite", "goshenite");
         itemMappings.put("Cerussite", "cerussite");
 
+        // FARMING category items
+        itemMappings.put("[ I ] Plant Fiber", "farmer_plant_fiber_I");
+        itemMappings.put("[ II ] Plant Fiber", "farmer_plant_fiber_II");
+        itemMappings.put("[ III ] Plant Fiber", "farmer_plant_fiber_III");
+        itemMappings.put("[ I ] Seed Pouch", "farmer_seed_pouch_I");
+        itemMappings.put("[ II ] Seed Pouch", "farmer_seed_pouch_II");
+        itemMappings.put("[ III ] Seed Pouch", "farmer_seed_pouch_III");
+        itemMappings.put("[ I ] Compost Dust", "farmer_compost_dust_I");
+        itemMappings.put("[ II ] Compost Dust", "farmer_compost_dust_II");
+        itemMappings.put("[ III ] Compost Dust", "farmer_compost_dust_III");
+        itemMappings.put("[ I ] Herbal Extract", "farmer_herb_extract_I");
+        itemMappings.put("[ II ] Herbal Extract", "farmer_herb_extract_II");
+        itemMappings.put("[ III ] Herbal Extract", "farmer_herb_extract_III");
+        itemMappings.put("[ I ] Mushroom Spores", "farmer_mushroom_spores_I");
+        itemMappings.put("[ II ] Mushroom Spores", "farmer_mushroom_spores_II");
+        itemMappings.put("[ III ] Mushroom Spores", "farmer_mushroom_spores_III");
+        itemMappings.put("[ I ] Beeswax Chunk", "farmer_beeswax_chunk_I");
+        itemMappings.put("[ II ] Beeswax Chunk", "farmer_beeswax_chunk_II");
+        itemMappings.put("[ III ] Beeswax Chunk", "farmer_beeswax_chunk_III");
+        itemMappings.put("[ I ] Druidic Essence", "farmer_druidic_essence_I");
+        itemMappings.put("[ II ] Druidic Essence", "farmer_druidic_essence_II");
+        itemMappings.put("[ III ] Druidic Essence", "farmer_druidic_essence_III");
+        itemMappings.put("[ I ] Golden Truffle", "farmer_golden_truffle_I");
+        itemMappings.put("[ II ] Golden Truffle", "farmer_golden_truffle_II");
+        itemMappings.put("[ III ] Golden Truffle", "farmer_golden_truffle_III");
+        itemMappings.put("[ I ] Ancient Grain Sheaf", "farmer_ancient_grain_I");
+        itemMappings.put("[ II ] Ancient Grain Sheaf", "farmer_ancient_grain_II");
+        itemMappings.put("[ III ] Ancient Grain Sheaf", "farmer_ancient_grain_III");
+
         // LOWISKO (fishing) category items
         itemMappings.put("[ I ] Algal", "alga_I");
         itemMappings.put("[ II ] Algal", "alga_II");

--- a/src/main/resources/item_list.yml
+++ b/src/main/resources/item_list.yml
@@ -1131,6 +1131,358 @@ cerussite:
     HideFlags: true
     Unbreakable: true
 
+# Przedmioty z kategorii FARMING
+farmer_plant_fiber_I:
+  Id: string
+  Display: '&9[ I ] Plant Fiber'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&7Basic crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_plant_fiber_II:
+  Id: string
+  Display: '&5[ II ] Plant Fiber'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&7Basic crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_plant_fiber_III:
+  Id: string
+  Display: '&6[ III ] Plant Fiber'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&7Basic crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_seed_pouch_I:
+  Id: wheat_seeds
+  Display: '&9[ I ] Seed Pouch'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&7Basic crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_seed_pouch_II:
+  Id: wheat_seeds
+  Display: '&5[ II ] Seed Pouch'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&7Basic crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_seed_pouch_III:
+  Id: wheat_seeds
+  Display: '&6[ III ] Seed Pouch'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&7Basic crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_compost_dust_I:
+  Id: bone_meal
+  Display: '&9[ I ] Compost Dust'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&7Basic crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_compost_dust_II:
+  Id: bone_meal
+  Display: '&5[ II ] Compost Dust'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&7Basic crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_compost_dust_III:
+  Id: bone_meal
+  Display: '&6[ III ] Compost Dust'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&7Basic crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_herb_extract_I:
+  Id: spider_eye
+  Display: '&9[ I ] Herbal Extract'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&aRare crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_herb_extract_II:
+  Id: spider_eye
+  Display: '&5[ II ] Herbal Extract'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&aRare crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_herb_extract_III:
+  Id: spider_eye
+  Display: '&6[ III ] Herbal Extract'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&aRare crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_mushroom_spores_I:
+  Id: brown_mushroom
+  Display: '&9[ I ] Mushroom Spores'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&aRare crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_mushroom_spores_II:
+  Id: brown_mushroom
+  Display: '&5[ II ] Mushroom Spores'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&aRare crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_mushroom_spores_III:
+  Id: brown_mushroom
+  Display: '&6[ III ] Mushroom Spores'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&aRare crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_beeswax_chunk_I:
+  Id: book
+  Display: '&9[ I ] Beeswax Chunk'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&aRare crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_beeswax_chunk_II:
+  Id: book
+  Display: '&5[ II ] Beeswax Chunk'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&aRare crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_beeswax_chunk_III:
+  Id: book
+  Display: '&6[ III ] Beeswax Chunk'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&aRare crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_druidic_essence_I:
+  Id: glow_ink_sac
+  Display: '&9[ I ] Druidic Essence'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&cLegendary crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_druidic_essence_II:
+  Id: glow_ink_sac
+  Display: '&5[ II ] Druidic Essence'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&cLegendary crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_druidic_essence_III:
+  Id: glow_ink_sac
+  Display: '&6[ III ] Druidic Essence'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&cLegendary crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_golden_truffle_I:
+  Id: golden_carrot
+  Display: '&9[ I ] Golden Truffle'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&cLegendary crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_golden_truffle_II:
+  Id: golden_carrot
+  Display: '&5[ II ] Golden Truffle'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&cLegendary crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_golden_truffle_III:
+  Id: golden_carrot
+  Display: '&6[ III ] Golden Truffle'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&cLegendary crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_ancient_grain_I:
+  Id: hay_block
+  Display: '&9[ I ] Ancient Grain Sheaf'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&cLegendary crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_ancient_grain_II:
+  Id: hay_block
+  Display: '&5[ II ] Ancient Grain Sheaf'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&cLegendary crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
+farmer_ancient_grain_III:
+  Id: hay_block
+  Display: '&6[ III ] Ancient Grain Sheaf'
+  Group: Farming
+  Category: FARMING
+  Enchantments:
+    DURABILITY: 10
+  Lore:
+    - '§o&cLegendary crafting material'
+  Options:
+    HideFlags: true
+    Unbreakable: true
+
 # Przedmioty z kategorii LOWISKO (Łowisko)
 alga_I:
   Id: horn_coral


### PR DESCRIPTION
## Summary
- add Farming item category and 27 new items
- wire farming items into pouch mappings and GUI order
- document new category and items

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e3331024832ab2f00c3cd1841cb7